### PR TITLE
Improve extraction speed and show progress

### DIFF
--- a/CanaryLauncher.csproj
+++ b/CanaryLauncher.csproj
@@ -57,7 +57,6 @@
     <Compile Include="src\ClientConfig.cs" />
     <Compile Include="src\MainWindow.xaml.cs" />
     <Compile Include="src\SplashScreen.xaml.cs" />
-    <PackageReference Include="Ionic.Zip" Version="1.9.1.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- drop DotNetZip dependency and use `System.IO.Compression` instead
- implement extraction progress feedback
- remove DotNetZip package reference

## Testing
- `msbuild CanaryLauncher.csproj /t:Build /p:Configuration=Release` *(fails: command not found)*
- `dotnet build CanaryLauncher.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bf487af4832bbb1d490986f102d4