### PR TITLE
Enable configurable client priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@
 You must configure the "launcher_config.json" url in MainWindow.cs and SplashScreen.cs
 
 In launcher_config.json you need to make necessary settings to use the launcher. (Read the explanation of how to use each configuration)
+
+New configuration option:
+
+* `clientPriority` - sets the priority class used when launching `client.exe`. Accepted values are the names from `ProcessPriorityClass` (for example `High` or `RealTime`).

--- a/launcher_config.json
+++ b/launcher_config.json
@@ -14,6 +14,7 @@
 		}
 	],
 	"clientFolder": "Tibia",
-	"newClientUrl" : "https://balrogot.com.br/download-client/balrogot-1412.zip",
-	"clientExecutable": "client.exe"
+        "newClientUrl" : "https://balrogot.com.br/download-client/balrogot-1412.zip",
+        "clientExecutable": "client.exe",
+        "clientPriority": "High"
 }

--- a/src/ClientConfig.cs
+++ b/src/ClientConfig.cs
@@ -16,9 +16,10 @@ namespace LauncherConfig
 		public bool replaceFolders { get; set; }
 		public ReplaceFolderName[] replaceFolderName { get; set; }
 		public string clientFolder { get; set; }
-		public string newClientUrl { get; set; }
-		public string newConfigUrl { get; set; }
-		public string clientExecutable { get; set; }
+                public string newClientUrl { get; set; }
+                public string newConfigUrl { get; set; }
+                public string clientExecutable { get; set; }
+                public string clientPriority { get; set; }
 
 		public static ClientConfig loadFromFile(string url)
 		{

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -40,17 +40,39 @@ namespace CanaryLauncherUpdate
                         new[] { "conf", "characterdata" },
                         StringComparer.OrdinalIgnoreCase);
 
-		private string GetLauncherPath(bool onlyBaseDirectory = false)
-		{
-			string launcherPath = "";
-			if (string.IsNullOrEmpty(clientConfig.clientFolder) || onlyBaseDirectory) {
-				launcherPath = AppDomain.CurrentDomain.BaseDirectory.ToString();
-			} else {
-				launcherPath = AppDomain.CurrentDomain.BaseDirectory.ToString() + "/" + clientConfig.clientFolder;
-			}
+                private string GetLauncherPath(bool onlyBaseDirectory = false)
+                {
+                        string launcherPath = "";
+                        if (string.IsNullOrEmpty(clientConfig.clientFolder) || onlyBaseDirectory) {
+                                launcherPath = AppDomain.CurrentDomain.BaseDirectory.ToString();
+                        } else {
+                                launcherPath = AppDomain.CurrentDomain.BaseDirectory.ToString() + "/" + clientConfig.clientFolder;
+                        }
 
-			return launcherPath;
-		}
+                        return launcherPath;
+                }
+
+                private void LaunchClient()
+                {
+                        string path = GetLauncherPath() + "/bin/" + clientExecutableName;
+                        if (File.Exists(path))
+                        {
+                                Process process = Process.Start(path);
+                                if (process != null)
+                                {
+                                        try
+                                        {
+                                                ProcessPriorityClass priority = ProcessPriorityClass.High;
+                                                if (!string.IsNullOrEmpty(clientConfig.clientPriority))
+                                                {
+                                                        Enum.TryParse(clientConfig.clientPriority, true, out priority);
+                                                }
+                                                process.PriorityClass = priority;
+                                        }
+                                        catch (Exception) { }
+                                }
+                        }
+                }
 
 		public MainWindow()
 		{
@@ -162,26 +184,26 @@ namespace CanaryLauncherUpdate
 			webClient.DownloadFileAsync(new Uri(urlClient), GetLauncherPath() + "/tibia.zip");
 		}
 
-		private void buttonPlay_Click(object sender, RoutedEventArgs e)
-		{
-			if (needUpdate == true || !Directory.Exists(GetLauncherPath()))
-			{
-				try
-				{
-					UpdateClient();
-				}
-				catch (Exception ex)
-				{
-					labelVersion.Text = ex.ToString();
-				}
-			}
-			else
-			{
-				if (clientDownloaded == true || !Directory.Exists(GetLauncherPath(true)))
-				{
-					Process.Start(GetLauncherPath() + "/bin/" + clientExecutableName);
-					this.Close();
-				}
+        private void buttonPlay_Click(object sender, RoutedEventArgs e)
+        {
+                if (needUpdate == true || !Directory.Exists(GetLauncherPath()))
+                {
+                        try
+                        {
+                                UpdateClient();
+                        }
+                        catch (Exception ex)
+                        {
+                                labelVersion.Text = ex.ToString();
+                        }
+                }
+                else
+                {
+                        if (clientDownloaded == true || !Directory.Exists(GetLauncherPath(true)))
+                        {
+                                LaunchClient();
+                                this.Close();
+                        }
 				else
 				{
 					try

--- a/src/SplashScreen.xaml.cs
+++ b/src/SplashScreen.xaml.cs
@@ -54,13 +54,26 @@ namespace CanaryLauncherUpdate
 			return "";
 		}
 
-		private void StartClient()
-		{
-			if (File.Exists(GetLauncherPath() + "/bin/" + clientExecutableName)) {
-				Process.Start(GetLauncherPath() + "/bin/" + clientExecutableName);
-				this.Close();
-			}
-		}
+                private void StartClient()
+                {
+                        if (File.Exists(GetLauncherPath() + "/bin/" + clientExecutableName)) {
+                                Process process = Process.Start(GetLauncherPath() + "/bin/" + clientExecutableName);
+                                if (process != null)
+                                {
+                                        try
+                                        {
+                                                ProcessPriorityClass priority = ProcessPriorityClass.High;
+                                                if (!string.IsNullOrEmpty(clientConfig.clientPriority))
+                                                {
+                                                        Enum.TryParse(clientConfig.clientPriority, true, out priority);
+                                                }
+                                                process.PriorityClass = priority;
+                                        }
+                                        catch (Exception) { }
+                                }
+                                this.Close();
+                        }
+                }
 
 		public SplashScreen()
 		{


### PR DESCRIPTION
## Summary
- add `clientPriority` option to config and README
- parse priority in ClientConfig
- launch client.exe with the configured priority

## Testing
- `dotnet build CanaryLauncher.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c341fd00832bbc652674908acaaa